### PR TITLE
Update content_selector for Accurate Article Parsing

### DIFF
--- a/backend/tag_guide.py
+++ b/backend/tag_guide.py
@@ -14,6 +14,11 @@ list_of_sites = [
         "selectors": {
             "url_selector": {"tag": "a", "class": "story-link"},
             "title_selector": {"tag": "h2", "class": "home-title"},
+            "content_selector": {
+                "tag": "p",
+                "ancestor_tag": "div",
+                "ancestor_class": "body-post__content",
+            },
         },
     },
     {
@@ -22,6 +27,11 @@ list_of_sites = [
         "selectors": {
             "url_selector": {"tag": "h2", "class": "c-card__title"},
             "title_selector": {"tag": "h2", "class": "c-card__title"},
+            "content_selector": {
+                "tag": "p",
+                "ancestor_tag": "div",
+                "ancestor_class": "c-entry-content",
+            },
         },
     },
     # Add more sites


### PR DESCRIPTION
This PR refines the content_selector configuration within the list_of_sites structure to enable accurate extraction of full article content from The Hacker News and Threatpost websites. The update ensures that only relevant text inside each article’s main content container is parsed, avoiding unrelated page elements. 

Change:
Before change:
list_of_sites = [
    {
        "name": "The Hacker News",
        "url": "https://thehackernews.com/",
        },
    },
    {
        "name": "SecurityWeek",
        "url": "https://threatpost.com/",
        },
    },
    # Add more sites
]

After change:
list_of_sites = [
    {
        "name": "The Hacker News",
        "url": "https://thehackernews.com/",
        "selectors": {
            "url_selector": {"tag": "a", "class": "story-link"},
            "title_selector": {"tag": "h2", "class": "home-title"},
            "content_selector": {
                "tag": "p",
                "ancestor_tag": "div",
                "ancestor_class": "body-post__content",
            },
        },
    },
    {
        "name": "SecurityWeek",
        "url": "https://threatpost.com/",
        "selectors": {
            "url_selector": {"tag": "h2", "class": "c-card__title"},
            "title_selector": {"tag": "h2", "class": "c-card__title"},
            "content_selector": {
                "tag": "p",
                "ancestor_tag": "div",
                "ancestor_class": "c-entry-content",
            },
        },
    },
    # Add more sites
]

Impact:

    Improves article parsing precision

    Reduces noise from unrelated HTML sections

    Prepares for consistent output in downstream LLM processing

    Prepare for fetch each article and extract its full content paragraphs

