### PR TITLE
Fix(logicalError): Ensure Correct Site–URL Mapping When Fetching Arti…

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -199,5 +199,5 @@ if __name__ == "__main__":
     #     init_db()  # Run it once to create Tables
     #     exit(1)
 
-    # Run the Flask app
+    # Run the Flask apps
     app.run(debug=True, port=5000)

--- a/backend/content.py
+++ b/backend/content.py
@@ -58,27 +58,27 @@ def fetch_content_data(soup_obj: BeautifulSoup, selector_map: dict):
             content_ancestor_tag, class_=content_class
         )
 
-        print(
-            f"Found {len(ancestor_containers)} ancestor containers with class '{content_class}'"
-        )
+        # print(
+        #     f"Found {len(ancestor_containers)} ancestor containers with class '{content_class}'"
+        # )
 
         content_items = []
         for container in ancestor_containers:
             items = container.find_all(content_tag)
             content_items.extend(items)
 
-        print(
-            f"Found {len(content_items)} {content_tag} tags within ancestor containers"
-        )
+        # print(
+        #     f"Found {len(content_items)} {content_tag} tags within ancestor containers"
+        # )
 
         contents = []
         for content in content_items:
             text = content.get_text(strip=True)
-            print(
-                f"Content text: {text[:100]}..."
-                if len(text) > 100
-                else f"Content text: {text}"
-            )
+            # print(
+            #     f"Content text: {text[:100]}..."
+            #     if len(text) > 100
+            #     else f"Content text: {text}"
+            # )
             if text:
                 contents.append(text)
         if not contents:
@@ -111,7 +111,8 @@ def debug_selector():
 debug_selector()
 
 
-#  Change this for the url of the cybermag.db
+# Connect the databse cybermag.db en stract each url
+# Make sure that each link is pair with it site selectors.
 test_url = [
     {
         "name": "The Hacker News",
@@ -125,27 +126,30 @@ test_url = [
 
 
 # 🔁 Main loop
-for i, site in enumerate(list_of_sites):
-    selector = site.get("selectors")
-    # url = site.get('url')
+for i, (site, test_url) in enumerate(zip(list_of_sites, test_url)):
+    # site contains selectors
+    # url_data contains the actual URL to fetch
+    selector = site.get("selectors", "Unknown")
+    name = site.get("name", "Unknown")
+    url = test_url.get("url", "Unknown")
+
     print(f"\n{'=' * 50}")
+    # ===========================================================
+    print(f"✅ Selectors found for site: {name}")
     print(f"Processing site {i + 1}/{len(list_of_sites)}")
-    print(f"✅ Selectors found for site: {site.get('name', 'Unknown')}")
+    print(f"✅ Site_Url: {url}")
 
     # get site selectors from dictionary list (list_of_sites)
     if not selector:
         print("❌ Content_selector was not found:")
     else:
-        content_only = {"content_selector": selector["content_selector"]}
-        print(f"✅ Selectors_tags found: {content_only}")
+        selector.get("content_selector", {})
+        # content_only = {"content_selector": selector.get("content_selector", {})}
+        print(f"✅ Selectors_tags found: {selector}")
 
-        # Check the logic @CrafteosK
-        for i, url in enumerate(test_url):
-            if "name" in url:
-                print(f"✅ {url['name']} {i + 1}/{len(url)}")
-
-            soup = get_response(url.get("url"))
-            if not soup:
-                print(print(f"❌ Could not get soup {url}"))
-            else:
-                data = fetch_content_data(soup, content_only)
+    soup = get_response(url)
+    if not soup:
+        print(print(f"❌ Could not get soup {url}"))
+    else:
+        data = fetch_content_data(soup, selector_map=selector)
+        # print(data)

--- a/backend/scraper.py
+++ b/backend/scraper.py
@@ -6,10 +6,10 @@ extracts the required data, and saves it to the database.
 """
 
 import traceback
-import requests
 from bs4 import BeautifulSoup
 from .models import save_report
 from .tag_guide import list_of_sites
+from .content import get_response
 
 
 # User-Agent header to mimic a browser request
@@ -21,24 +21,6 @@ from .tag_guide import list_of_sites
 # You can find more User-Agent strings at https://www.whatismybrowser.com/detect
 # or https://developers.whatismybrowser.com/useragents/explore/
 # or you can use a library like fake-useragent to generate random User-Agent strings.
-headers = {
-    "User-Agent": (
-        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
-        "AppleWebKit/537.36 (KHTML, like Gecko) "
-        "Chrome/92.0.4515.159 Safari/537.36"
-    )
-}
-
-
-# Function to get the HTML content of a page
-def get_response(page_url: str) -> BeautifulSoup | None:
-    """Fetch and parse the HTML content of the given URL."""
-    try:
-        response = requests.get(page_url, headers=headers, timeout=10)
-        return BeautifulSoup(response.text, "html.parser")
-    except ImportError as e:
-        print(f"❌ Failed to get {page_url}: Error type: {e}")
-        return None
 
 
 # Function to extract article titles and URLs from the soup object


### PR DESCRIPTION
…cle Content
🔄 Fix: Ensure Correct Site–URL Mapping When Fetching Article Content
🛠 Summary
This PR resolves an issue where each site's content selectors were being incorrectly applied to all test URLs, resulting in repeated or mismatched article processing. The problem stemmed from separate loops over list_of_sites and test_url, causing selectors from one site to be used on unrelated URLs.
✅ What was changed
⦁	Replaced nested loop with a single zip(list_of_sites, test_url) loop to ensure each site's selector is matched only with its corresponding article URL.
⦁	Ensured accurate content extraction by applying the right content_selector to the correct HTML document.
⦁	Improved logging clarity by aligning loop indices and log messages to reflect the correct site–URL pair.
🧪 Behavior before
⦁	Site 1 would incorrectly process both URL 1 and URL 2 using its own selector.
⦁	Site 2 would then reprocess both URLs again, often with partial or no matches.
✅ Behavior after
⦁	Site 1 now processes only URL 1 using its correct selectors.
⦁	Site 2 processes only URL 2 with its corresponding selectors.
🧠 Improvements planned (optional)
⦁	Add automated validation to test selector–URL compatibility.
⦁	Include tests to detect mismatches between selectors and page structure in the future.