### PR TITLE
Fix/report query

### DIFF
--- a/Docs-history/fix/report_query.txt
+++ b/Docs-history/fix/report_query.txt
@@ -1,0 +1,40 @@
+Check the way we are querying from report table
+
+
+How many time & where are we querying all data from report table
+
+1. def get_paginated_articles(page: int, limit: int):
+2. def reports_card():
+3. def get_single_report(post_id):
+
+There are Tree funtion in __Init__.py that query individualy from report 
+
+Note: remove 
+
+# Recommended best practices for your project
+
+Use pagination everywhere for user-facing article lists
+
+Avoid .all() in request handlers
+
+Cache frequently accessed article lists
+
+Precompute report cards and store results
+
+Add database indexes on fields used in filters/search
+
+Consider SQL query logging in development to detect over-querying
+
+Practical rule you can follow
+
+OK in development and admin tools:
+
+Model.query.all()
+
+Preferred in APIs or UI lists:
+
+paginate()
+
+limit()/offset()
+
+filtered queries

--- a/Docs-history/fix/report_query.txt
+++ b/Docs-history/fix/report_query.txt
@@ -38,3 +38,8 @@ paginate()
 limit()/offset()
 
 filtered queries
+
+# Solution: 
+
+previews: articles = Cybersecurity_Reports.query.all() query all 
+Newer: articles = Cybersecurity_Reports.query.limit(50) Apply a ``LIMIT`` to the query and return the newly resulting

--- a/backend/flaskr/__init__.py
+++ b/backend/flaskr/__init__.py
@@ -102,7 +102,7 @@ def create_app(test_config=None):
     def reports_card():
         try:
             # Fetch all records via ORM
-            articles = Cybersecurity_Reports.query.all() # replace for  
+            articles = Cybersecurity_Reports.query.limit(50) # replace for  
             """paginate()
                 limit()/offset()
                 filtered queries"""
@@ -120,7 +120,7 @@ def create_app(test_config=None):
     @app.route("/api/post/<int:post_id>", methods=["GET"])
     def get_single_report(post_id):
         try:
-            articles = Cybersecurity_Reports.query.all() # replace for  
+            articles = Cybersecurity_Reports.query.limit(50) # replace for  
             """paginate()
                 limit()/offset()
                 filtered queries"""

--- a/backend/flaskr/__init__.py
+++ b/backend/flaskr/__init__.py
@@ -102,7 +102,10 @@ def create_app(test_config=None):
     def reports_card():
         try:
             # Fetch all records via ORM
-            articles = Cybersecurity_Reports.query.all()
+            articles = Cybersecurity_Reports.query.all() # replace for  
+            """paginate()
+                limit()/offset()
+                filtered queries"""
             articles_data = [a.to_dict() for a in articles]
             
             return jsonify({
@@ -117,7 +120,10 @@ def create_app(test_config=None):
     @app.route("/api/post/<int:post_id>", methods=["GET"])
     def get_single_report(post_id):
         try:
-            articles = Cybersecurity_Reports.query.all()
+            articles = Cybersecurity_Reports.query.all() # replace for  
+            """paginate()
+                limit()/offset()
+                filtered queries"""
             article = next((a for a in articles if a.id == post_id), None)
             if article:
                 return jsonify({"success": True, "article": article.to_dict()}), 200


### PR DESCRIPTION
Check the way we are querying from report table


How many time & where are we querying all data from report table

1. def get_paginated_articles(page: int, limit: int):
2. def reports_card():
3. def get_single_report(post_id):

There are Tree funtion in __Init__.py that query individualy from report 

Note: remove 

# Recommended best practices for your project

Use pagination everywhere for user-facing article lists

Avoid .all() in request handlers

Cache frequently accessed article lists

Precompute report cards and store results

Add database indexes on fields used in filters/search

Consider SQL query logging in development to detect over-querying

Practical rule you can follow

OK in development and admin tools:

Model.query.all()

Preferred in APIs or UI lists:

paginate()

limit()/offset()

filtered queries

# Solution: 

previews: articles = Cybersecurity_Reports.query.all() query all 
Newer: articles = Cybersecurity_Reports.query.limit(50) Apply a ``LIMIT`` to the query and return the newly resulting 